### PR TITLE
Update documentation

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,6 +1,6 @@
 # Configuration
 
-All configuration entries can be modified by setting enviroment variables that follow the following format (double underscores):
+All configuration entries can be modified by setting environment variables that follow the following format (double underscores):
 
 ```
 BEAGLE__{SECTION}__{KEY}
@@ -21,7 +21,7 @@ Each section below represents a single entry in the configuration file:
     -   For example `bolt://localhost:7687`
 -   `username`: Username to authenticate with
 -   `password`: Password for the username
--   `batch_size`: Number of items to send to Neo4J at once using UNWIND querys.
+-   `batch_size`: Number of items to send to Neo4J at once using UNWIND queries.
     -   Default value is `1000`
 
 ### `dgraph`

--- a/docs/design_overview.md
+++ b/docs/design_overview.md
@@ -44,7 +44,7 @@ The following is a list of currently support Node Types
 | Deleted       | Process     | File        | A process deleted this file                                                               |
 | Copied        | Process     | File        | A process copied this file (the copied file will have a `CopiedTo` edge to the dest file) |
 | Loaded        | Process     | File        | A process loaded a function from this file.                                               |
-| ConnectedTo   | Process     | IPAddress   | A process initated a network connection to this address                                   |
+| ConnectedTo   | Process     | IPAddress   | A process initiated a network connection to this address                                   |
 | HTTPRequestTo | Process     | URI         | A process made a HTTP Request to this URI                                                 |
 | DNSQueryFor   | Process     | Domain      | A process performed a DNS request for this domain.                                        |
 | ChangedValue  | Process     | RegistryKey | A process changed the value of this registry key                                          |

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,6 +1,6 @@
 # Development
 
-Development primarly involves creating a datasource and transformer. For backend creation, see the existing `Neo4J` and `DGraph` classes for how to leverage `NetworkX` to transform a created graph.
+Development primarily involves creating a datasource and transformer. For backend creation, see the existing `Neo4J` and `DGraph` classes for how to leverage `NetworkX` to transform a created graph.
 
 Developing a datasource mainly involves forwarding events from it one by one into a transformer. This section will be split into two different approaches, one using a specific Transformer, and one using the `GenericTransformer`.
 
@@ -96,7 +96,7 @@ class ChangedValue(Edge):
 
 ### Using Edge Classes
 
-Once an edge class is defined, and is set as an attribute on a node class. Adding the edge can be done by inserting the target node into the defaultdict, and optionally adding data to that instance:
+Once an edge class is defined, it is set as an attribute on a node class. Adding the edge can be done by inserting the target node into the defaultdict, and optionally adding data to that instance as shown below:
 
 Let's say we want to add a `ChangeValue` edge from a `Process` to a `RegistryKey`, and that the edge `defaultdict` is defined on `changed_value` attribute:
 
@@ -322,4 +322,4 @@ def transform(self, event: dict) -> Optional[Tuple]:
         return None
 ```
 
-That's it! now the transformer and datasource can work together to yeild nodes to be placed into a graph by the backends.
+That's it! now the transformer and datasource can work together to yield nodes to be placed into a graph by the backends.


### PR DESCRIPTION
This PR fixes the following spelling and grammatical errors in `configuration.md`, `design_overview.md` and `development.md`:
1. `enviroment` -> `environment`
2. `querys` -> `queries` (based on my assumption of the intention, let me know if this isn't what was intended)
3. `initated` -> `initiated`
4. `primarly` -> `primarily`
5. `Once an edge class is defined, and ....` -> `Once an edge class is defined, it ...`
6.  `yeild` -> `yield` 