### PR TITLE
ad-hoc JSON to graph route

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,7 @@ matrix:
       before_install:
         - choco install python3 --version 3.6.8
         - export PATH="/c/Python36:/c/Python36/Scripts:$PATH"
+        - export TMPDIR=.
         - pip install setuptools wheel
 
     - name: "Windows Python 3.7"
@@ -44,6 +45,7 @@ matrix:
       before_install:
           - choco install python3 --version 3.7.3
           - export PATH="/c/Python37:/c/Python37/Scripts:$PATH"
+          - export TMPDIR=.
           - pip install setuptools wheel
 
     - name: "MacOSX Python 3.6"

--- a/beagle/backends/networkx.py
+++ b/beagle/backends/networkx.py
@@ -204,6 +204,12 @@ class NetworkX(Backend):
 
         nx.set_node_attributes(self.G, {node_id: {"data": current_data}})
 
+    @classmethod
+    def graph_to_json(cls, graph: nx.MultiDiGraph) -> dict:
+        backend = cls(nodes=[])
+        backend.G = graph
+        return backend.to_json()
+
     def to_json(self) -> dict:
         """Convert the graph to JSON, which can later be used be read in using
         networkx::

--- a/beagle/datasources/darpa_tc_json.py
+++ b/beagle/datasources/darpa_tc_json.py
@@ -2,11 +2,11 @@
 # https://github.com/darpa-i2o/Transparent-Computing
 from typing import Generator
 
-from beagle.datasources.json_data import JSONData
+from beagle.datasources.json_data import JSONFile
 from beagle.transformers import DRAPATCTransformer
 
 
-class DARPATCJson(JSONData):
+class DARPATCJson(JSONFile):
     name = "Darpa TC3 JSON"
     transformers = [DRAPATCTransformer]  # type: ignore
     category = "Darpa TC3"

--- a/beagle/datasources/json_data.py
+++ b/beagle/datasources/json_data.py
@@ -6,11 +6,9 @@ from beagle.datasources.base_datasource import DataSource
 from beagle.transformers import GenericTransformer
 
 
-class JSONData(DataSource):
-    """A generic data source which returns events from a JSON file.
-    """
+class JSONFile(DataSource):
 
-    name = "JSON Data"
+    name = "JSON File"
     transformers = [GenericTransformer]
     category = "Generic Data"
 
@@ -35,3 +33,22 @@ class JSONData(DataSource):
         else:
             for line in handle.readlines():
                 yield json.loads(line)
+
+
+class JSONData(DataSource):
+    """A generic data source which returns events one by one
+    """
+
+    name = "JSON Data"
+    transformers = [GenericTransformer]
+    category = "Generic Data"
+
+    def __init__(self, events: List[Dict]) -> None:
+        self._events = events
+
+    def events(self) -> Generator[dict, None, None]:
+        for event in self._events:
+            yield event
+
+    def metadata(self) -> dict:
+        return {}

--- a/beagle/web/api/views.py
+++ b/beagle/web/api/views.py
@@ -430,12 +430,7 @@ def adhoc():
     if not isinstance(events, list):
         events = [events]
 
-    # Create a tempfile for the data.
-    tmpfile = tempfile.NamedTemporaryFile()
-    tmpfile.write(json.dumps(events).encode())
-    tmpfile.seek(0)
-
-    g = JSONData(tmpfile.name).to_graph()
+    g = JSONData(events).to_graph()
 
     return jsonify({"data": NetworkX.graph_to_json(g)})
 

--- a/beagle/web/api/views.py
+++ b/beagle/web/api/views.py
@@ -11,9 +11,11 @@ from flask.helpers import make_response
 
 import beagle.datasources  # noqa: F401
 import beagle.transformers  # noqa: F401
+from beagle.backends.networkx import NetworkX
 from beagle.common import logger
 from beagle.config import Config
 from beagle.datasources.base_datasource import ExternalDataSource
+from beagle.datasources.json_data import JSONData
 from beagle.web.api.models import Graph
 from beagle.web.server import db
 
@@ -405,6 +407,37 @@ def new():
 
     response.headers.add("Access-Control-Allow-Origin", "*")
     return response
+
+
+@api.route("/adhoc", methods=["POST"])
+def adhoc():
+    """Allows for ad-hoc transformation of generic JSON Data based on one of two CIM models:
+
+    1. The Beagle CIM Model (defined in `constants.py`)
+    2. The OSSEM Model (defined in https://github.com/Cyb3rWard0g/OSSEM)
+    """
+
+    valid_cim_formats = ["beagle"]
+    data = request.get_json()
+    events = data["data"]
+    cim_format = data.get("cim", "beagle")
+
+    if str(cim_format).lower() not in valid_cim_formats:
+        response = jsonify({"message": f"cim_format must be in {cim_format}"})
+        response.headers.add("Access-Control-Allow-Origin", "*")
+        return response
+
+    if not isinstance(events, list):
+        events = [events]
+
+    # Create a tempfile for the data.
+    tmpfile = tempfile.NamedTemporaryFile()
+    tmpfile.write(json.dumps(events).encode())
+    tmpfile.seek(0)
+
+    g = JSONData(tmpfile.name).to_graph()
+
+    return jsonify({"data": NetworkX.graph_to_json(g)})
 
 
 @api.route("/categories/")

--- a/tests/datasource/test_json_data.py
+++ b/tests/datasource/test_json_data.py
@@ -1,21 +1,21 @@
 import json
-from beagle.datasources.json_data import JSONData
+from beagle.datasources.json_data import JSONFile
 
 
 def test_init():
-    d = JSONData("data/tc3/ta1-cadets-e3-official.json")
+    d = JSONFile("data/tc3/ta1-cadets-e3-official.json")
     assert d.file_path == "data/tc3/ta1-cadets-e3-official.json"
 
 
 def test_metadata():
-    d = JSONData("data/tc3/ta1-cadets-e3-official.json")
+    d = JSONFile("data/tc3/ta1-cadets-e3-official.json")
     assert d.metadata() == {"filename": "ta1-cadets-e3-official.json"}
 
 
 def test_events_in_newline(tmpdir):
     p = tmpdir.mkdir("json_data").join("data.json")
     p.write("\n".join([json.dumps(x) for x in [{"foo": "bar"}, {"foo": "tar"}]]))
-    events = list(JSONData(p).events())
+    events = list(JSONFile(p).events())
 
     assert all([x in events for x in [{"foo": "bar"}, {"foo": "tar"}]])
 
@@ -24,4 +24,4 @@ def test_event_in_array(tmpdir):
     p = tmpdir.mkdir("json_data").join("data.json")
     p.write(json.dumps([{"foo": "bar"}, {"foo": "tar"}]))
 
-    assert list(JSONData(p).events()) == [{"foo": "bar"}, {"foo": "tar"}]
+    assert list(JSONFile(p).events()) == [{"foo": "bar"}, {"foo": "tar"}]

--- a/tests/web/api/test_views.py
+++ b/tests/web/api/test_views.py
@@ -1,4 +1,4 @@
-from beagle.constants import EventTypes, FieldNames
+from beagle.constants import EventTypes, FieldNames, Protocols
 
 
 def test_missing_params(client):
@@ -42,3 +42,37 @@ def test_adhoc_single_event(client):
 
     assert len(resp["nodes"]) > 0
     assert len(resp["links"]) > 0
+
+
+def test_adhoc_array(client):
+    events = [
+        {
+            FieldNames.PARENT_PROCESS_IMAGE: "<PATH_SAMPLE.EXE>",
+            FieldNames.PARENT_PROCESS_IMAGE_PATH: "\\",
+            FieldNames.PARENT_PROCESS_ID: "3420",
+            FieldNames.PARENT_COMMAND_LINE: "",
+            FieldNames.PROCESS_IMAGE: "cmd.exe",
+            FieldNames.PROCESS_IMAGE_PATH: "<SYSTEM32>",
+            FieldNames.COMMAND_LINE: "",
+            FieldNames.PROCESS_ID: "3712",
+            FieldNames.TIMESTAMP: 5,
+            FieldNames.EVENT_TYPE: EventTypes.PROCESS_LAUNCHED,
+        },
+        {
+            FieldNames.IP_ADDRESS: "24.151.31.150",
+            FieldNames.PROTOCOL: Protocols.TCP,
+            FieldNames.PORT: 465,
+            FieldNames.PROCESS_IMAGE: "<PATH_SAMPLE.EXE>",
+            FieldNames.PROCESS_IMAGE_PATH: "\\",
+            FieldNames.PROCESS_ID: "1748",
+            FieldNames.COMMAND_LINE: "",
+            FieldNames.EVENT_TYPE: EventTypes.CONNECTION,
+        },
+    ]
+
+    resp = client.post("/api/adhoc", json={"data": events}).json["data"]
+
+    assert len(resp["nodes"]) > 0
+
+    all_types = [l["type"] for l in resp["links"]]
+    assert "Connected To" in all_types

--- a/tests/web/api/test_views.py
+++ b/tests/web/api/test_views.py
@@ -1,3 +1,7 @@
+from beagle.constants import EventTypes, FieldNames
+import json
+
+
 def test_missing_params(client):
     resp = client.post("/api/new", data={})
     assert resp.status_code == 400
@@ -19,3 +23,23 @@ def test_misisng_params(client):
     )
     assert resp.status_code == 400
     assert "Missing" in resp.json["message"]
+
+
+def test_adhoc_single_event(client):
+    event = {
+        FieldNames.PARENT_PROCESS_IMAGE: "<PATH_SAMPLE.EXE>",
+        FieldNames.PARENT_PROCESS_IMAGE_PATH: "\\",
+        FieldNames.PARENT_PROCESS_ID: "3420",
+        FieldNames.PARENT_COMMAND_LINE: "",
+        FieldNames.PROCESS_IMAGE: "cmd.exe",
+        FieldNames.PROCESS_IMAGE_PATH: "<SYSTEM32>",
+        FieldNames.COMMAND_LINE: "",
+        FieldNames.PROCESS_ID: "3712",
+        FieldNames.TIMESTAMP: 5,
+        FieldNames.EVENT_TYPE: EventTypes.PROCESS_LAUNCHED,
+    }
+
+    resp = client.post("/api/adhoc", json={"data": [event]}).json["data"]
+
+    assert len(resp["nodes"]) > 0
+    assert len(resp["links"]) > 0

--- a/tests/web/api/test_views.py
+++ b/tests/web/api/test_views.py
@@ -1,5 +1,4 @@
 from beagle.constants import EventTypes, FieldNames
-import json
 
 
 def test_missing_params(client):


### PR DESCRIPTION
Adds an API Route that allows someone to send arbitrary JSON data and get back a graph with minimal configuration (given it follows the schema)